### PR TITLE
Dawn.SourceGen: Bump TargetFramework to netstandard2.1

### DIFF
--- a/DawnLib.SourceGen/DawnLib.SourceGen.csproj
+++ b/DawnLib.SourceGen/DawnLib.SourceGen.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
@@ -26,7 +26,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="bin\$(Configuration)\netstandard2.0\DawnLib.SourceGen.dll"
+        <None Include="bin\$(Configuration)\netstandard2.1\DawnLib.SourceGen.dll"
             Pack="true"
             PackagePath="analyzers/dotnet/cs"
             Visible="false" />


### PR DESCRIPTION
This makes TargetFramework consistent throughout the whole repository, which opens patch to unifying duplicated code of common extensions.

Newtonsoft.Json still needs to reference netstandard2.0 directories, as that is what it is built for[1].

[1]: https://www.nuget.org/packages/newtonsoft.json/#supportedframeworks-body-tab