### PR TITLE
Unify StringExtensions.ToCapitalized: Dawn.Utils & Dawn.SourceGen

### DIFF
--- a/DawnLib.SourceGen/Extensions/StringExtensions.cs
+++ b/DawnLib.SourceGen/Extensions/StringExtensions.cs
@@ -1,6 +1,5 @@
-﻿using System.Linq;
+﻿namespace Dawn.SourceGen.Extensions;
 
-namespace Dawn.SourceGen.Extensions;
 public static class StringExtensions
 {
     public static string ToCapitalized(this string input)
@@ -8,6 +7,7 @@ public static class StringExtensions
         if (string.IsNullOrWhiteSpace(input))
             return string.Empty;
 
-        return input.First().ToString().ToUpper() + string.Join("", input.Skip(1));
+        // Relying on a bold but practical assumption that 1 char == 1 grapheme
+        return input.Substring(0, 1).ToUpperInvariant() + input.Substring(1);
     }
 }

--- a/DawnLib/src/Utils/Extensions/StringExtensions.cs
+++ b/DawnLib/src/Utils/Extensions/StringExtensions.cs
@@ -12,7 +12,8 @@ public static class StringExtensions
             return string.Empty;
         }
 
-        return input.First().ToString().ToUpper() + input[1..];
+        // Relying on a bold but practical assumption that 1 char == 1 grapheme
+        return input[..1].ToUpperInvariant() + input[1..];
     }
 
     public static string RemoveEnd(this string input, string end)


### PR DESCRIPTION
It looks like we are dealing with file names and code identifiers, so
hopefully we won't have to support anything crazy like digraphs or emojis.

Use plain simple Substring() instead of Linq, and use locale-agnostic
ToUpperInvariant() just in case.

---

old commit message:

~~Thanks to target framework being netstandard2.1 now, the new syntax can
be used in SourceGen mirrored method too.~~

~~Setting Unicode concerns aside, Substring (the underlying method of
square brackets here) should be more efficient than joining an iterator.~~
