### PR TITLE
Dawn.SourceGen: Clarify why TargetFramework is netstandard2.0

### DIFF
--- a/DawnLib.SourceGen/DawnLib.SourceGen.csproj
+++ b/DawnLib.SourceGen/DawnLib.SourceGen.csproj
@@ -1,6 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <!--
+            Note: Source Generators are .NET Standard 2.0 components.
+            Do NOT update TargetFramework to netstandard2.1 or anything else.
+            See https://devblogs.microsoft.com/dotnet/introducing-c-source-generators/
+         -->
         <TargetFramework>netstandard2.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>


### PR DESCRIPTION
I feel like it warrants a comment to avoid future confusion.