### PR TITLE
SourceGen: Generate #nullable enable

### DIFF
--- a/DawnLib.SourceGen/AST/FileWriterVisitor.cs
+++ b/DawnLib.SourceGen/AST/FileWriterVisitor.cs
@@ -93,6 +93,8 @@ public class FileWriterVisitor : ISymbolVisitor
             _builder.AppendLine($"using {@using};");
         }
 
+        _builder.AppendLine("#nullable enable");
+
         if (!string.IsNullOrWhiteSpace(codeFile.Namespace))
             _builder.AppendLine($"namespace {codeFile.Namespace};");
 


### PR DESCRIPTION
The #nullable is strongly suggested to be enabled in order to use explicitly nullable types like these:

```cs
public static NamespacedKey<DawnUnlockableItemInfo>? GetByReflection(string name) {
	return (NamespacedKey<DawnUnlockableItemInfo>?)typeof(UnlockableItemKeys).GetField(name)?.GetValue(null);
}
```

This patch removes 22 warnings from `dotnet build` output like this:

	//DawnLib/DawnLib/obj/Debug/netstandard2.1/DawnLib.SourceGen/Dawn.SourceGen.KeyCollectionSourceGenerator/extra.MoonKeys.g.cs(6,43):
	warning CS8669: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
	Auto-generated code requires an explicit '#nullable' directive in source.

According to the documentation, even if/when we add nullable support to the whole csproj project, it still needs to opt-in for generated code:

> The global nullable context does not apply for generated code files.
> Under either strategy, the nullable context is disabled for any
> source file marked as generated. [...]
> Generators can opt-in using the #nullable preprocessor directive.

https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references#nullable-context