### PR TITLE
Add Unity specific code analyzers

### DIFF
--- a/DawnLib.Compatibility/DawnLib.Compatibility.csproj
+++ b/DawnLib.Compatibility/DawnLib.Compatibility.csproj
@@ -30,6 +30,10 @@
         <PackageReference Include="BepInEx.Core" Version="5.*" PrivateAssets="all"/>
         <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" PrivateAssets="all"/>
         <PackageReference Include="LethalCompany.GameLibs.Steam" Version="*-*" PrivateAssets="all"/>
+        <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.25.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="UnityEngine.Modules" Version="2022.3.62" PrivateAssets="all"/>
 
         <ProjectReference Include="..\DawnLib\DawnLib.csproj" PrivateAssets="all" />

--- a/DawnLib.Dusk/DawnLib.Dusk.csproj
+++ b/DawnLib.Dusk/DawnLib.Dusk.csproj
@@ -45,6 +45,10 @@
         <PackageReference Include="BepInEx.Core" Version="5.*" PrivateAssets="all"/>
         <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" PrivateAssets="all"/>
         <PackageReference Include="LethalCompany.GameLibs.Steam" Version="73.0.0-ngd.0" PrivateAssets="all"/>
+        <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.25.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="UnityEngine.Modules" Version="2022.3.62" PrivateAssets="all"/>
         <ProjectReference Include="..\DawnLib.Interfaces\DawnLib.Interfaces.csproj" PrivateAssets="all" />
 

--- a/DawnLib/DawnLib.csproj
+++ b/DawnLib/DawnLib.csproj
@@ -38,6 +38,10 @@
         <PackageReference Include="BepInEx.Core" Version="5.*" PrivateAssets="all" Publicize="true" />
         <PackageReference Include="IAmBatby.LethalLevelLoader" Publicize="true" Version="1.4.0" PrivateAssets="all" />
         <PackageReference Include="LethalCompany.GameLibs.Steam" Version="73.0.0-ngd.0" PrivateAssets="all" Publicize="true"/>
+        <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.25.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="mrov-TerminalFormatter" Version="0.2.29" PrivateAssets="all"/>
         <PackageReference Include="Pooble-LCBetterSaves" Version="1.7.3" PrivateAssets="all" />
         <ProjectReference Include="..\DawnLib.Interfaces\DawnLib.Interfaces.csproj" PrivateAssets="all" />


### PR DESCRIPTION
Reduces amount of false positive warnings by ~30 instances.

Out of 5 projects in this MSBuild solution, Interfaces and SourceGen do not contain any Unity-specific code, so only other three reference the package.