### PR TITLE
Fix AddGeneratedFile target's Outputs file path

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
         <PathMap>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))=./</PathMap>
     </PropertyGroup>
 
-    <Target Name="AddGeneratedFile" BeforeTargets="BeforeCompile;CoreCompile" Inputs="$(MSBuildAllProjects)" Outputs="$(IntermediateOutputPath)GeneratedFile.cs">
+    <Target Name="AddGeneratedFile" BeforeTargets="BeforeCompile;CoreCompile" Inputs="$(MSBuildAllProjects)" Outputs="$(IntermediateOutputPath)MyPluginInfo.cs">
         <PropertyGroup>
             <BepInExPluginGuid Condition="'$(BepInExPluginGuid)' == ''">$(AssemblyName)</BepInExPluginGuid>
             <BepInExPluginName Condition="'$(BepInExPluginName)' == ''">$(Product)</BepInExPluginName>
@@ -40,8 +40,10 @@ namespace Dawn
         </PropertyGroup>
         <ItemGroup>
             <Compile Include="$(GeneratedFilePath)" />
+            <!-- Append to FileWrites so the file will be removed on clean -->
             <FileWrites Include="$(GeneratedFilePath)" />
         </ItemGroup>
+        <!-- Generate plugin info file here -->
         <WriteLinesToFile Lines="$(GeneratedText)" File="$(GeneratedFilePath)" WriteOnlyWhenDifferent="true" Overwrite="true" />
     </Target>
 


### PR DESCRIPTION
Setting correct Output should reduce extra work on recompilation.

There is a duplication of MyPluginInfo.cs file path, and it doesn't seem to be possible to set it in a PropertyGroup outside of Target.

Also add brief comments on why there are seemingly two similar items about writing to file.