### PR TITLE
Fix warnings related to null checks using TryGet pattern instead

### DIFF
--- a/DawnLib.Dusk/src/API/Definitions/EntityReplacement/Enemies/EnemyAIExtensions.cs
+++ b/DawnLib.Dusk/src/API/Definitions/EntityReplacement/Enemies/EnemyAIExtensions.cs
@@ -1,18 +1,22 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
 using Dawn.Interfaces;
 
 namespace Dusk;
 
 public static class EnemyAIExtensions
 {
-    public static DuskEnemyReplacementDefinition? GetEnemyReplacement(this EnemyAI enemyAI)
+    public static bool TryGetEnemyReplacement(this EnemyAI enemyAI, [NotNullWhen(true)] out DuskEnemyReplacementDefinition? replacement)
     {
-        DuskEnemyReplacementDefinition? enemyReplacementDefinition = (DuskEnemyReplacementDefinition?)((ICurrentEntityReplacement)enemyAI).CurrentEntityReplacement;
-        return enemyReplacementDefinition;
+        replacement = ((ICurrentEntityReplacement)enemyAI).CurrentEntityReplacement as DuskEnemyReplacementDefinition;
+        return replacement != null;
     }
 
-    internal static bool HasEnemyReplacement(this EnemyAI enemyAI)
+    [Obsolete($"Use {nameof(TryGetEnemyReplacement)}")]
+    public static DuskEnemyReplacementDefinition? GetEnemyReplacement(this EnemyAI enemyAI)
     {
-        return enemyAI.GetEnemyReplacement() != null;
+        enemyAI.TryGetEnemyReplacement(out var replacement);
+        return replacement;
     }
 
     internal static void SetEnemyReplacement(this EnemyAI enemyAI, DuskEnemyReplacementDefinition enemyReplacementDefinition)

--- a/DawnLib.Dusk/src/API/Definitions/EntityReplacement/Items/GrabbableObjectExtensions.cs
+++ b/DawnLib.Dusk/src/API/Definitions/EntityReplacement/Items/GrabbableObjectExtensions.cs
@@ -1,18 +1,22 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
 using Dawn.Interfaces;
 
 namespace Dusk;
 
 public static class GrabbableObjectExtensions
 {
-    public static DuskItemReplacementDefinition? GetGrabbableObjectReplacement(this GrabbableObject grabbableObject)
+    public static bool TryGetGrabbableObjectReplacement(this GrabbableObject grabbableObject, [NotNullWhen(true)] out DuskItemReplacementDefinition? output)
     {
-        DuskItemReplacementDefinition? grabbableObjectReplacementDefinition = (DuskItemReplacementDefinition?)((ICurrentEntityReplacement)grabbableObject).CurrentEntityReplacement;
-        return grabbableObjectReplacementDefinition;
+        output = ((ICurrentEntityReplacement)grabbableObject).CurrentEntityReplacement as DuskItemReplacementDefinition;
+        return output != null;
     }
 
-    internal static bool HasGrabbableObjectReplacement(this GrabbableObject grabbableObject)
+    [Obsolete($"Use {nameof(TryGetGrabbableObjectReplacement)}")]
+    public static DuskItemReplacementDefinition? GetGrabbableObjectReplacement(this GrabbableObject grabbableObject)
     {
-        return grabbableObject.GetGrabbableObjectReplacement() != null;
+        grabbableObject.TryGetGrabbableObjectReplacement(out var output);
+        return output;
     }
 
     internal static void SetGrabbableObjectReplacement(this GrabbableObject grabbableObject, DuskItemReplacementDefinition itemReplacementDefinition)

--- a/DawnLib.Dusk/src/Internal/Patches/EntityReplacementRegistrationPatch.cs
+++ b/DawnLib.Dusk/src/Internal/Patches/EntityReplacementRegistrationPatch.cs
@@ -175,11 +175,11 @@ static class EntityReplacementRegistrationPatch
                 c.Index += 2;
                 c.EmitDelegate<Func<GrabbableObject, float, float>>((self, existing) =>
                 {
-                    if (!self.HasGrabbableObjectReplacement())
+                    if (!self.TryGetGrabbableObjectReplacement(out var replacement))
                     {
                         return existing;
                     }
-                    return self.GetGrabbableObjectReplacement().VerticalOffset;
+                    return replacement.VerticalOffset;
                 });
                 continue;
             }
@@ -192,11 +192,11 @@ static class EntityReplacementRegistrationPatch
                 c.Index += 2;
                 c.EmitDelegate<Func<GrabbableObject, int, int>>((self, existing) =>
                 {
-                    if (!self.HasGrabbableObjectReplacement())
+                    if (!self.TryGetGrabbableObjectReplacement(out var replacement))
                     {
                         return existing;
                     }
-                    return self.GetGrabbableObjectReplacement().FloorYOffset;
+                    return replacement.FloorYOffset;
                 });
                 continue;
             }
@@ -313,7 +313,7 @@ static class EntityReplacementRegistrationPatch
             return;
         }
 
-        if (self.HasGrabbableObjectReplacement())
+        if (self.TryGetGrabbableObjectReplacement(out var _))
         {
             orig(self);
             return;
@@ -411,11 +411,11 @@ static class EntityReplacementRegistrationPatch
                 c.Emit(OpCodes.Ldarg_0);
                 c.EmitDelegate<Func<AudioClip[], EnemyAI, AudioClip[]>>((existingAudioClips, self) =>
                 {
-                    if (!self.HasEnemyReplacement())
+                    if (!self.TryGetEnemyReplacement(out var replacement))
                     {
                         return existingAudioClips;
                     }
-                    return self.GetEnemyReplacement().AudioClips;
+                    return replacement.AudioClips;
                 });
                 continue;
             }
@@ -548,7 +548,7 @@ static class EntityReplacementRegistrationPatch
             return;
         }
 
-        if (self.HasEnemyReplacement())
+        if (self.TryGetEnemyReplacement(out var _))
         {
             return;
         }


### PR DESCRIPTION
Why doing something twice in a row for no reason, while also generating false-positive null dereference diagnostics?

NotNullWhen attribute ensures clean warning-free integration with `if` conditions. Existing public methods were marked with an Obsolete attribute, but redundant internal `Has*` methods were removed.

All in all, that's another 6 warnings out of the way.