### PR TITLE
Terminal: Port to [NotNullWhen(true)] attribute

### DIFF
--- a/DawnLib/src/API/Terminal/TerminalKeywordBuilder.cs
+++ b/DawnLib/src/API/Terminal/TerminalKeywordBuilder.cs
@@ -1,8 +1,9 @@
 using System;
 using System.Collections.Generic;
-using UnityEngine;
+using System.Diagnostics.CodeAnalysis;
 using Dawn.Internal;
 using Dawn.Utils;
+using UnityEngine;
 
 namespace Dawn;
 public class TerminalKeywordBuilder
@@ -28,11 +29,11 @@ public class TerminalKeywordBuilder
     internal static List<TerminalKeyword> WordsThatAcceptInput { get; private set; } = [];
     private TerminalKeyword _keyword;
 
-    private static bool WordAlreadyExists(string word, out TerminalKeyword existingKeyword)
+    private static bool WordAlreadyExists(string word, [NotNullWhen(true)] out TerminalKeyword? existingKeyword)
     {
         if (TerminalRefs.Instance == null)
         {
-            existingKeyword = null!;
+            existingKeyword = null;
             foreach (TerminalKeyword keyword in AllTerminalKeywords)
             {
                 if (word.CompareStringsInvariant(keyword.word))
@@ -55,7 +56,7 @@ public class TerminalKeywordBuilder
     // <remarks>WARNING: Do not use this constructor if you do not wish to override other existing terminal keywords with the same word!</remarks>
     internal TerminalKeywordBuilder(string name, string word)
     {
-        if (WordAlreadyExists(word, out TerminalKeyword existingKeywordWithSameWord))
+        if (WordAlreadyExists(word, out var existingKeywordWithSameWord))
         {
             _keyword = existingKeywordWithSameWord;
             DawnPlugin.Logger.LogWarning($"Keyword Override! Replacing keyword [{_keyword.word}] results");
@@ -74,7 +75,7 @@ public class TerminalKeywordBuilder
     // <remarks>DawnKeywordType determines if a matching keyword is overwritten or if the keyword word will be modified at creation</remarks>
     internal TerminalKeywordBuilder(string name, string word, ITerminalKeyword.DawnKeywordType keywordPriority)
     {
-        if (WordAlreadyExists(word, out TerminalKeyword existingKeywordWithSameWord))
+        if (WordAlreadyExists(word, out var existingKeywordWithSameWord))
         {
             ITerminalKeyword.DawnKeywordType existingPriority = existingKeywordWithSameWord.GetKeywordPriority();
             if (existingPriority <= keywordPriority)

--- a/DawnLib/src/API/TerminalCommands/.TerminalCommandRegistration.cs
+++ b/DawnLib/src/API/TerminalCommands/.TerminalCommandRegistration.cs
@@ -102,7 +102,7 @@ public class TerminalCommandRegistration
         self.SetLastVerb(null!);
         self.SetLastNoun(null!);
 
-        if (self.DawnTryResolveKeyword(playerWord, out TerminalKeyword NonNullResult))
+        if (self.DawnTryResolveKeyword(playerWord, out var NonNullResult))
         {
             self.UpdateLastKeywordParsed(NonNullResult);
             self.SetLastCommand(playerWord.GetExactMatch(NonNullResult.word));
@@ -121,7 +121,7 @@ public class TerminalCommandRegistration
 
     private static TerminalKeyword ParseWordPrefix(On.Terminal.orig_ParseWord orig, Terminal self, string playerWord, int specificityRequired)
     {
-        if (self.DawnTryResolveKeyword(playerWord, out TerminalKeyword NonNullResult))
+        if (self.DawnTryResolveKeyword(playerWord, out var NonNullResult))
         {
             self.UpdateLastKeywordParsed(NonNullResult);
             self.SetLastCommand(playerWord.GetExactMatch(NonNullResult.word));
@@ -163,7 +163,7 @@ public class TerminalCommandRegistration
 
             if (string.IsNullOrEmpty(keyword.GetKeywordDescription()))
             {
-                if (keyword.TryGetKeywordInfoText(out string result))
+                if (keyword.TryGetKeywordInfoText(out var result))
                 {
                     keyword.SetKeywordDescription(result.Trim());
                 }

--- a/DawnLib/src/Utils/Extensions/TerminalExtensions.cs
+++ b/DawnLib/src/Utils/Extensions/TerminalExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Dawn.Internal;
 
@@ -67,7 +69,7 @@ public static class TerminalExtensions
         return ((ITerminal)terminal).DawnLastVerb;
     }
 
-    public static bool TryGetKeywordInfoText(this TerminalKeyword terminalKeyword, out string text)
+    public static bool TryGetKeywordInfoText(this TerminalKeyword terminalKeyword, [NotNullWhen(true)] out string? text)
     {
         text = string.Empty;
         CompatibleNoun matchedCompatibleNoun = TerminalRefs.InfoKeyword.compatibleNouns.FirstOrDefault(x => x.noun.word == terminalKeyword.word);
@@ -80,7 +82,7 @@ public static class TerminalExtensions
         return true;
     }
 
-    public static bool TryGetKeyword(this Terminal terminal, string keyWord, out TerminalKeyword terminalKeyword)
+    public static bool TryGetKeyword(this Terminal terminal, string keyWord, [NotNullWhen(true)] out TerminalKeyword? terminalKeyword)
     {
         List<TerminalKeyword> keyWordList = [.. terminal.terminalNodes.allKeywords];
 
@@ -94,7 +96,7 @@ public static class TerminalExtensions
             }
         }
 
-        terminalKeyword = null!;
+        terminalKeyword = null;
         return false;
     }
 
@@ -313,9 +315,9 @@ public static class TerminalExtensions
         return word;
     }
 
-    public static bool DawnTryResolveKeyword(this Terminal terminal, string input, out TerminalKeyword word)
+    public static bool DawnTryResolveKeyword(this Terminal terminal, string input, [NotNullWhen(true)] out TerminalKeyword? word)
     {
-        word = null!;
+        word = null;
 
         //empty input, return false
         if (string.IsNullOrWhiteSpace(input))


### PR DESCRIPTION
In case of public methods, a brief investigation proved that `?`
nullable mark is not part of method signature when applied to reference
types; it just becomes a yet another parameter attribute in IL,
namely [NullableAttribute], so it is a backward-compatible change that
doesn't break ABI. Regarding source compatibility, API users might get
a new warning CS8600 if they are using concrete type instead of a `var`
keyword:

> Converting null literal or possible null value to non-nullable type.