### PR TITLE
Weights: Use correct nullability in implementing interface type

### DIFF
--- a/DawnLib/src/API/Weights/SimpleWeighted.cs
+++ b/DawnLib/src/API/Weights/SimpleWeighted.cs
@@ -27,7 +27,7 @@ public class SimpleContextualProvider<T, TBase>(T value) : IContextualProvider<T
     public T Provide(TBase info) => value;
 }
 
-public class MatchingKeyContextualProvider<T, TBase>(NamespacedKey<TBase> targetKey, T value) : IContextualProvider<T, TBase> where TBase : INamespaced<TBase>
+public class MatchingKeyContextualProvider<T, TBase>(NamespacedKey<TBase> targetKey, T value) : IContextualProvider<T?, TBase> where TBase : INamespaced<TBase>
 {
     public T? Provide(TBase info)
     {
@@ -35,7 +35,7 @@ public class MatchingKeyContextualProvider<T, TBase>(NamespacedKey<TBase> target
     }
 }
 
-public class HasTagContextualProvider<T, TBase>(NamespacedKey tag, T value) : IContextualProvider<T, TBase> where TBase : INamespaced<TBase>
+public class HasTagContextualProvider<T, TBase>(NamespacedKey tag, T value) : IContextualProvider<T?, TBase> where TBase : INamespaced<TBase>
 {
     public T? Provide(TBase info)
     {


### PR DESCRIPTION
Resolves two rightfully chunky warnings:

    //DawnLib/src/API/Weights/SimpleWeighted.cs(32,15): warning CS8766: Nullability of reference types in return type of 'T? MatchingKeyContextualProvider<T, TBase>.Provide(TBase info)' doesn't match implicitly implemented member 'T IContextualProvider<T, TBase>.Provide(TBase info)' (possibly because of nullability attributes).
    //DawnLib/DawnLib/src/API/Weights/SimpleWeighted.cs(40,15): warning CS8766: Nullability of reference types in return type of 'T? HasTagContextualProvider<T, TBase>.Provide(TBase info)' doesn't match implicitly implemented member 'T IContextualProvider<T, TBase>.Provide(TBase info)' (possibly because of nullability attributes).