### PR TITLE
DuskVehicleDefinition: Take Generate*Config and nullability into account

### DIFF
--- a/DawnLib.Dusk/src/API/Definitions/Vehicles/DuskVehicleDefinition.cs
+++ b/DawnLib.Dusk/src/API/Definitions/Vehicles/DuskVehicleDefinition.cs
@@ -83,7 +83,10 @@ public class DuskVehicleDefinition : DuskContentDefinition<DawnVehicleInfo>, INa
         using ConfigContext section = mod.ConfigManager.CreateConfigSectionForBundleData(AssetBundleData);
         Config = CreateVehicleConfig(section);
 
-        Cost = Config.Cost.Value;
+        if (GenerateCostConfig && Config.Cost is { } ConfigCost)
+        {
+            Cost = Config.Cost.Value;
+        }
         if (Config.DisableUnlockRequirements?.Value ?? false && TerminalPredicate)
         {
             TerminalPredicate = null;

--- a/DawnLib.Dusk/src/Internal/Patches/VehicleRegistrationPatch.cs
+++ b/DawnLib.Dusk/src/Internal/Patches/VehicleRegistrationPatch.cs
@@ -203,7 +203,7 @@ static class VehicleRegistrationPatch
             BuyableVehicle buyableVehicle = new()
             {
                 vehicleDisplayName = vehicleDefinition.VehicleDisplayName,
-                creditsWorth = vehicleDefinition.Config.Cost.Value,
+                creditsWorth = vehicleDefinition.Cost,
                 vehiclePrefab = vehicleDefinition.BuyableVehiclePreset.VehiclePrefab,
                 secondaryPrefab = vehicleDefinition.BuyableVehiclePreset.SecondaryPrefab
             };
@@ -225,7 +225,7 @@ static class VehicleRegistrationPatch
                 .SetClearPreviousText(true)
                 .SetMaxCharactersToType(35)
                 .SetBuyVehicleIndex(currentVehicleIndex)
-                .SetItemCost(vehicleDefinition.Config.Cost.Value)
+                .SetItemCost(vehicleDefinition.Cost)
                 .SetPlaySyncedClip(0)
                 .Build();
             vehicleDefinition.DawnVehicleInfo.ConfirmPurchaseNode = confirmDuskNode;
@@ -249,7 +249,7 @@ static class VehicleRegistrationPatch
                 .SetMaxCharactersToType(15)
                 .SetIsConfirmationNode(true)
                 .SetBuyVehicleIndex(currentVehicleIndex)
-                .SetItemCost(vehicleDefinition.Config.Cost.Value)
+                .SetItemCost(vehicleDefinition.Cost)
                 .SetOverrideOptions(true)
                 .SetTerminalOptions(buyNodeNouns)
                 .Build();


### PR DESCRIPTION
As per discussion[1], `RegisterVehicles` happens after `DuskVehicleDefinition` registration, so it is safe to assume the Cost field is final and ready to be used directly. No other code accesses `DuskVehicleDefinition.Config` outside of its own file anyway.

Partially fixes #71

[1]: https://github.com/TeamXiaolan/DawnLib/issues/71#issuecomment-3852280030