### PR TITLE
DuskEntityReplacementDefinition: Fix nullability issues

### DIFF
--- a/DawnLib.Dusk/src/API/Definitions/EntityReplacement/DuskEntityReplacementDefinition.cs
+++ b/DawnLib.Dusk/src/API/Definitions/EntityReplacement/DuskEntityReplacementDefinition.cs
@@ -83,11 +83,17 @@ public abstract class DuskEntityReplacementDefinition : DuskContentDefinition, I
         }
     }
 
+    internal void RegisterAsDefault()
+    {
+        IsDefault = true;
+        Weights = new WeightTableBuilder<DawnMoonInfo, SpawnWeightContext>().SetGlobalWeight(100).Build();
+    }
+
     public override void Register(DuskMod mod)
     {
         if (IsDefault)
         {
-            Weights = new WeightTableBuilder<DawnMoonInfo, SpawnWeightContext>().SetGlobalWeight(100).Build();
+            RegisterAsDefault();
             return;
         }
 

--- a/DawnLib.Dusk/src/Internal/Patches/EntityReplacementRegistrationPatch.cs
+++ b/DawnLib.Dusk/src/Internal/Patches/EntityReplacementRegistrationPatch.cs
@@ -228,8 +228,7 @@ static class EntityReplacementRegistrationPatch
                 if (!mapObjectInfo.CustomData.TryGet(Key, out List<DuskMapObjectReplacementDefinition>? list))
                 {
                     DuskMapObjectReplacementDefinition vanilla = ScriptableObject.CreateInstance<DuskMapObjectReplacementDefinition>();
-                    vanilla.IsDefault = true;
-                    vanilla.Register(null);
+                    vanilla.RegisterAsDefault();
                     list = [vanilla];
                     mapObjectInfo.CustomData.Set(Key, list);
                 }
@@ -273,8 +272,7 @@ static class EntityReplacementRegistrationPatch
                 if (!unlockableItemInfo.CustomData.TryGet(Key, out List<DuskUnlockableReplacementDefinition>? list))
                 {
                     DuskUnlockableReplacementDefinition vanilla = ScriptableObject.CreateInstance<DuskUnlockableReplacementDefinition>();
-                    vanilla.IsDefault = true;
-                    vanilla.Register(null);
+                    vanilla.RegisterAsDefault();
                     list = [vanilla];
                     unlockableItemInfo.CustomData.Set(Key, list);
                 }
@@ -295,8 +293,7 @@ static class EntityReplacementRegistrationPatch
                 if (!itemInfo.CustomData.TryGet(Key, out List<DuskItemReplacementDefinition>? list))
                 {
                     DuskItemReplacementDefinition vanilla = ScriptableObject.CreateInstance<DuskItemReplacementDefinition>();
-                    vanilla.IsDefault = true;
-                    vanilla.Register(null);
+                    vanilla.RegisterAsDefault();
                     list = [vanilla];
                     itemInfo.CustomData.Set(Key, list);
                 }
@@ -524,8 +521,7 @@ static class EntityReplacementRegistrationPatch
                 if (!enemyInfo.CustomData.TryGet(Key, out List<DuskEnemyReplacementDefinition>? list))
                 {
                     DuskEnemyReplacementDefinition defaultSkin = ScriptableObject.CreateInstance<DuskEnemyReplacementDefinition>();
-                    defaultSkin.IsDefault = true;
-                    defaultSkin.Register(null);
+                    defaultSkin.RegisterAsDefault();
                     list = [defaultSkin];
                     enemyInfo.CustomData.Set(Key, list);
                 }


### PR DESCRIPTION
Not sure if this is the best way, or whether it makes sense to leave the check in the `Register(DuskMod mod)` method, but it gets the job done.

Fixes another 4 build-time warnings.