### PR TITLE
Fix Action delegate's nullability

### DIFF
--- a/DawnLib.Dusk/src/API/Definitions/Achievements/DuskAchievementDefinition.cs
+++ b/DawnLib.Dusk/src/API/Definitions/Achievements/DuskAchievementDefinition.cs
@@ -75,7 +75,7 @@ public abstract class DuskAchievementDefinition : DuskContentDefinition, INamesp
         }
 
         Completed = true;
-        DuskAchievementHandler.OnAchievementUnlocked.Invoke(this);
+        DuskAchievementHandler.OnAchievementUnlocked?.Invoke(this);
         return Completed;
     }
 

--- a/DawnLib.Dusk/src/API/Definitions/Achievements/DuskAchievementHandler.cs
+++ b/DawnLib.Dusk/src/API/Definitions/Achievements/DuskAchievementHandler.cs
@@ -8,7 +8,7 @@ namespace Dusk;
 
 static class DuskAchievementHandler
 {
-    public static Action<DuskAchievementDefinition> OnAchievementUnlocked = delegate { };
+    public static Action<DuskAchievementDefinition>? OnAchievementUnlocked;
 
     internal static void LoadAll()
     {


### PR DESCRIPTION
In AchievementUIGetCanvas destructor removes a delegate from DuskAchievementHandler.OnAchievementUnlocked, which triggers a warning about possible null assignment.

```cs
    protected override void OnDestroy()
    {
        DuskAchievementHandler.OnAchievementUnlocked -= QueuePopup;
    }
```

Turns out, delgates implicitly implement `-=` operator in a way that "If removal results in an empty list, the result is `null`."[1] So from static typing POV, it doesn't matter that `OnAchievementUnlocked` action is initialized with an empty `delegate { }` — it still sees the code as nullable.

The fix is to consistently treat such action delegate as nullable. That also means that a dummy `delegate { }` initialization is redundant.

[1]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/subtraction-operator#delegate-removal