### PR TITLE
DatePredicate: Mark _namespacedKey as nullable

### DIFF
--- a/DawnLib.Dusk/src/API/DuskPredicates/DatePredicate.cs
+++ b/DawnLib.Dusk/src/API/DuskPredicates/DatePredicate.cs
@@ -31,7 +31,7 @@ public class DatePredicate : DuskPredicate
     [field: SerializeField]
     public DawnDateTime DawnEndDateTime { get; private set; }
 
-    private NamespacedKey _namespacedKey = null;
+    private NamespacedKey? _namespacedKey = null;
 
     public override bool Evaluate()
     {


### PR DESCRIPTION
It is already being treated as such at the top of the Evaluate() method.