### PR TITLE
ConfigContext: Remove default value for Bind(T defaultValue) parameter

### DIFF
--- a/DawnLib.Dusk/src/API/Config/ConfigContext.cs
+++ b/DawnLib.Dusk/src/API/Config/ConfigContext.cs
@@ -8,7 +8,7 @@ public class ConfigContext(ConfigFile file, string heading) : IDisposable
 
     public void Dispose() { }
 
-    public ConfigEntry<T> Bind<T>(string name, string description, T defaultValue = default)
+    public ConfigEntry<T> Bind<T>(string name, string description, T defaultValue)
     {
         return file.CleanedBind(heading, name, defaultValue, description);
     }


### PR DESCRIPTION
According to Microsoft documentation, this is a source break at worst, NOT a binary break.

Pros:
- It is never used without an actual value for the defaultValue argument.
- Not providing any defaultValue never made much sense.

Cons:
- It is part of public API.

https://learn.microsoft.com/en-us/dotnet/core/compatibility/library-change-rules

> ❌ DISALLOWED: Changing the default value of a property, field, or parameter
>
> Changing or removing a parameter default value is not a binary break.
> Removing a parameter default value is a source break, and changing a
> parameter default value could result in a behavioral break after
> recompilation.