### PR TITLE
TerminalTextModifier

### DIFF
--- a/DawnLib/src/API/Terminal/TerminalTextModifier.cs
+++ b/DawnLib/src/API/Terminal/TerminalTextModifier.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Text.RegularExpressions;
 using Dawn.Internal;
 using Dawn.Utils;
@@ -6,18 +7,34 @@ using Dawn.Utils;
 namespace Dawn;
 
 /// <summary>
-/// For simple text modifications.
+/// The match "index" for non-regex text modifications
 /// </summary>
 /// <remarks>
-/// FirstIndex = get the Index of first match,
-/// LastIndex = get the Index of last match,
-/// EveryIndex = get every match
+/// First finds the index of the first match.
+/// Last finds the index of the last match.
+/// All finds every index of the match.
 /// </remarks>
-public enum TextIndex
+public enum MatchIndex
 {
-    FirstIndex,
-    LastIndex,
-    EveryIndex
+    First,
+    Last,
+    All
+}
+
+/// <summary>
+/// The match "insert style" for non-regex text modifications
+/// </summary>
+/// <remarks>
+/// ReplaceMatch will just replace the matching text with the specified text.
+/// Before will insert the specified text before the matching text.
+/// After will insert the specified text after the matching text.
+/// </remarks>
+[Flags]
+public enum MatchInsert
+{
+    ReplaceMatch = 0,
+    Before = 1 << 0,
+    After = 1 << 1
 }
 
 /// <summary>
@@ -31,18 +48,18 @@ public class TerminalTextModifier
     private IProvider<string> AddedTextProvider;
 
     // optional stuff, defaults to replace every matching text in every node (null NodeToProcess & NodeKeyword), not using Regex
-    private bool ShouldReplaceText = true;
     private bool RegexPattern = false;
     private TerminalNode? NodeToProcess;
     private string? NodeKeyword;
-    private TextIndex IndexStyle = TextIndex.EveryIndex;
+    private MatchIndex IndexStyle = MatchIndex.All;
+    private MatchInsert InsertStyle = MatchInsert.ReplaceMatch;
 
 
     /// <summary>
     /// Create a TerminalTextModifier instance. It will automatically be subscribed to the event that runs during Terminal.TextPostProcess
     /// </summary>
     /// <param name="textToFind">The specific text string you wish to find and modify</param>
-    /// <param name="additionalTextProvider">The string provider that will be used during text modification. If unsure what kind of provider to use, use SimpleProvider</param>
+    /// <param name="additionalTextProvider">The string provider that will be used during text modification. If unsure what kind of provider to use, use <see cref="SimpleProvider{T}"/></param>
     public TerminalTextModifier(string textToFind, IProvider<string> additionalTextProvider)
     {
         TextToFind = textToFind;
@@ -51,9 +68,9 @@ public class TerminalTextModifier
     }
 
     /// <summary>
-    /// Use this method to change the TextToFind string at runtime.
+    /// Use this method to change the string you are parsing for at runtime.
     /// </summary>
-    /// <param name="textToFind">The specific text string you wish to find and modify</param>
+    /// <param name="textToFind">The specific string you wish to find and modify</param>
     public TerminalTextModifier ChangeTextToFind(string textToFind)
     {
         TextToFind = textToFind;
@@ -72,23 +89,31 @@ public class TerminalTextModifier
     }
 
     /// <summary>
-    /// Determine whether this textmodifier should replace the text or simply insert after it.
+    /// Set a MatchInsert style for this text modifier, the default MatchInsert style will replace the matching text completely.
     /// </summary>
-    /// <param name="value">True = Replace, False = Insert After</param>
+    /// <param name="style">
+    /// ReplaceMatch (default) completely replaces the matching text with your added content.
+    /// Before will insert your added content before the matching text.
+    /// After will insert your added content after the matching text.
+    /// </param>
     /// <remarks>
-    /// NOTE: This value does not need to be set when using Regex instead of simple matching.
+    /// NOTE: You can set this value to both Before and After to insert your content before and after the matching content (at the specified MatchIndex)
+    /// Also, MatchInsert is not used with Regex Pattern matching.
     /// </remarks>
-    public TerminalTextModifier SetReplaceText(bool value)
+    public TerminalTextModifier SetInsertStyle(MatchInsert style)
     {
-        ShouldReplaceText = value;
+        InsertStyle = style;
         return this;
     }
 
     /// <summary>
-    /// Set the TextIndex style for simple text modification. This will determine what matching text is modified.
+    /// Set the MatchIndex style for this text modifier. This will determine which matching text should be modified.
     /// </summary>
-    /// <param name="indexStyle">The expected style which can be: FirstIndex, LastIndex, EveryIndex</param>
-    public TerminalTextModifier SetIndexStyle(TextIndex indexStyle)
+    /// <param name="indexStyle">The expected style which can be: First, Last, All</param>
+    /// <remarks>
+    /// NOTE: MatchIndex is not used with Regex Pattern matching.
+    /// </remarks>
+    public TerminalTextModifier SetIndexStyle(MatchIndex indexStyle)
     {
         IndexStyle = indexStyle;
         return this;
@@ -150,35 +175,32 @@ public class TerminalTextModifier
         if (RegexPattern)
         {
             Regex regex = new(TextToFind);
-            DawnPlugin.Logger.LogDebug($"""
+
+            // uncomment below if any issues are encountered with text modification via regex
+            /* DawnPlugin.Logger.LogDebug($"""
             Processing text modifier (regex) on node - {terminalNode}
             Regex ({TextToFind}) matches found {regex.Matches(TextToFind).Count}
             AddedText - {textToAdd} (before regex format conversion)
-            """);
-            DawnPlugin.Logger.LogDebug($"");
+            """); */
+
             currentText = regex.Replace(currentText, textToAdd);
             return;
         }
 
-        DawnPlugin.Logger.LogDebug($"""
+        // uncomment below if any issues are encountered with text modification
+
+        /* DawnPlugin.Logger.LogDebug($"""
             Processing text modifier (non-regex) on node - {terminalNode}
             IndexStyle - {IndexStyle}
             TextToFind - {TextToFind}
             AddedText - {textToAdd}
-            """);
+            """); */
 
-        if (ShouldReplaceText)
-        {
-            currentText = currentText.TextReplacer(IndexStyle, TextToFind, textToAdd);
-        }
-        else
-        {
-            currentText = currentText.TextAdder(IndexStyle, TextToFind, textToAdd);
-        }
+        currentText = currentText.TextModify(IndexStyle, InsertStyle, TextToFind, textToAdd);
     }
 
-    // could probably be private or moved to another class if useful elsewhere, not sure at the moment
-    internal static TerminalNode GetNodeFromWord(string word)
+    // maybe worthy of a terminal extension in the future, keeping private for now
+    private static TerminalNode GetNodeFromWord(string word)
     {
         if (TerminalRefs.Instance.TryGetKeyword(word, out TerminalKeyword? terminalKeyword))
         {

--- a/DawnLib/src/DawnTesting.cs
+++ b/DawnLib/src/DawnTesting.cs
@@ -1,25 +1,46 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Dawn;
 
 internal class DawnTesting
 {
+    private static string AdjectivesExample()
+    {
+        List<string> values = ["VERY ", "MANY ", "INCREDIBLY "];
+        var rand = new Random();
+        return values[rand.Next(0, values.Count)];
+    }
+
     internal static void TestCommands()
     {
+        // replaces any mention of the word planet for the word moon with a yellowish highlight in any node
         TerminalTextModifier changeAll = new("planet", new SimpleProvider<string>("<mark=#ffff001A>moon</mark>"));
-        TerminalTextModifier insertAll = new TerminalTextModifier("the list", new SimpleProvider<string>("<i>ing</i>"))
-            .SetReplaceText(false);
-        TerminalTextModifier InsertFirst = new TerminalTextModifier("\n\n\n", new SimpleProvider<string>("<align=\"center\">---</align>\n"))
-            .SetReplaceText(false)
-            .SetIndexStyle(TextIndex.FirstIndex);
-        TerminalTextModifier ReplaceLast = new TerminalTextModifier("\n", new SimpleProvider<string>("\n<align=\"center\">----</align>\n\n"))
-            .SetIndexStyle(TextIndex.LastIndex);
 
+        // inserts quotes before and after any mention of the word commands in any node
+        TerminalTextModifier insertBeforeAndAfter = new TerminalTextModifier("commands", new SimpleProvider<string>("\""))
+            .SetInsertStyle(MatchInsert.Before | MatchInsert.After);
+
+        // inserts a random adjective from a set list before the word useful in any node
+        TerminalTextModifier insertBefore = new TerminalTextModifier("useful", new FuncProvider<string>(AdjectivesExample))
+            .SetInsertStyle(MatchInsert.Before);
+
+        // inserts an italicized ing after any mention of the phrase "the list" in any node
+        TerminalTextModifier insertAll = new TerminalTextModifier("the list", new SimpleProvider<string>("<i>ing</i>"))
+            .SetInsertStyle(MatchInsert.After);
+
+        // inserts some stylized dashes after the first 3 newlines of any node shown in the terminal (top of the screen)
+        TerminalTextModifier InsertFirst = new TerminalTextModifier("\n\n\n", new SimpleProvider<string>("<align=\"center\">---</align>\n"))
+            .SetInsertStyle(MatchInsert.After)
+            .SetIndexStyle(MatchIndex.First);
+
+        // replaces the last new line of any node with some stylized dashes
+        TerminalTextModifier ReplaceLast = new TerminalTextModifier("\n", new SimpleProvider<string>("\n<align=\"center\">----</align>\n\n"))
+            .SetIndexStyle(MatchIndex.Last);
 
         // regex example, will make sure to capture the specific line containing record regardless of what kind of changes the other modifiers make
         // text to add must use $& to keep the existing text
         TerminalTextModifier helpAdd = new TerminalTextModifier("record.*\\S", new SimpleProvider<string>("$&\n\n>VERSION\nDisplay Dawnlib's current version"))
-            .SetReplaceText(true)
             .UseRegexPattern(true)
             .SetNodeFromKeyword("help");
 

--- a/DawnLib/src/Internal/Patches/TerminalPatches.cs
+++ b/DawnLib/src/Internal/Patches/TerminalPatches.cs
@@ -9,7 +9,7 @@ static class TerminalPatches
 {
     // below delegate/event is used for TerminalTextModifiers
     internal delegate void TextPostProcess(ref string currentText, TerminalNode node);
-    internal static event TextPostProcess OnProcessNodeText = null!;
+    internal static event TextPostProcess? OnProcessNodeText;
     internal static void Init()
     {
         On.Terminal.LoadNewNodeIfAffordable += HandlePredicate;

--- a/DawnLib/src/Utils/Extensions/StringExtensions.cs
+++ b/DawnLib/src/Utils/Extensions/StringExtensions.cs
@@ -120,58 +120,44 @@ public static class StringExtensions
     }
 
     /// <summary>
-    /// Replace matching string with a replacement string
+    /// Modify a string to insert/replace added content at the position of a specific matching string
     /// </summary>
     /// <param name="value">Full string being modified</param>
     /// <param name="indexStyle">This will determine what matching text values are modified.</param>
-    /// <param name="matching">This is the matching string we are finding and replacing</param>
-    /// <param name="replacement">This is the string content we are replacing the matching string with</param>
-    public static string TextReplacer(this string value, TextIndex indexStyle, string matching, string replacement)
+    /// <param name="insertStyle">This will determine whether we replace the matching string completely or insert our text before/after it</param>
+    /// <param name="matching">This is the matching string we are searching for to add our content.</param>
+    /// <param name="addedContent">This is the string content we are adding.</param>
+    public static string TextModify(this string value, MatchIndex indexStyle, MatchInsert insertStyle, string matching, string addedContent)
     {
         if (string.IsNullOrEmpty(value) || !value.Contains(matching))
         {
-            //DawnPlugin.Logger.LogWarning($"TextReplacer: Unable to find expected text - {textToReplace} in string - {value}. Text remains unchanged");
             return value;
         }
 
-        if (indexStyle is TextIndex.EveryIndex)
+        if (indexStyle is MatchIndex.All)
         {
-            // replace every instance of our matching string
-            return value.Replace(matching, replacement);
-        }
-        else
-        {
-            // depending on the style will either return the first or last index value of the textToReplace
-            int index = (indexStyle is TextIndex.FirstIndex) ? value.IndexOf(matching) : value.LastIndexOf(matching);
-            return value.Remove(index, matching.Length).Insert(index, replacement);
-        }
-    }
-
-    /// <summary>
-    /// Add text after a matching string value
-    /// </summary>
-    /// <param name="value">Full string being modified</param>
-    /// <param name="indexStyle">This will determine what matching text values are modified.</param>
-    /// <param name="matching">This is the matching string we are finding and adding content after</param>
-    /// <param name="addedContent">This is the string content we are adding after the matching string</param>
-    public static string TextAdder(this string value, TextIndex indexStyle, string matching, string addedContent)
-    {
-        if (string.IsNullOrEmpty(value) || !value.Contains(matching))
-        {
-            //DawnPlugin.Logger.LogWarning($"TextAdder: Unable to find expected text - {textToFind} in string - {value}. Text remains unchanged");
-            return value;
-        }
-
-        if (indexStyle is TextIndex.EveryIndex)
-        {
-            // add content to every instance of our matching string
-            return value.Replace(matching, matching + addedContent);
+            return insertStyle switch
+            {
+                MatchInsert.ReplaceMatch => value.Replace(matching, addedContent),
+                MatchInsert.Before => value.Replace(matching, addedContent + matching),
+                MatchInsert.After => value.Replace(matching, matching + addedContent),
+                MatchInsert.Before | MatchInsert.After => value.Replace(matching, addedContent + matching + addedContent),
+                _ => value,
+            };
         }
         else
         {
             // depending on the style will either return the first or last index value of the textToFind
-            int index = (indexStyle is TextIndex.FirstIndex) ? value.IndexOf(matching) : value.LastIndexOf(matching);
-            return value.Insert(index + matching.Length, addedContent);
+            int index = (indexStyle is MatchIndex.First) ? value.IndexOf(matching) : value.LastIndexOf(matching);
+
+            return insertStyle switch
+            {
+                MatchInsert.ReplaceMatch => value.Remove(index, matching.Length).Insert(index, addedContent),
+                MatchInsert.Before => value.Insert(index, addedContent),
+                MatchInsert.After => value.Insert(index + matching.Length, addedContent),
+                MatchInsert.Before | MatchInsert.After => value.Remove(index, matching.Length).Insert(index, addedContent + matching + addedContent),
+                _ => value,
+            };
         }
     }
 


### PR DESCRIPTION
Rework of PR #63 this adds a new class for modifying terminalnode displaytext following original Terminal.TextPostProcess method

Allows for two styles:
- Simple
- Regex (less performant, according to online searches)

Regex vs Simple is determined by bool RegexPattern

In Simple you can then either replace OR insert after the matching string your IProvider<string> value.
- Replace vs Insert is determined by bool ShouldReplaceText
- The index of your replace/insert is determined by IndexStyle (an enum that switches between first, last, and everything)

This can be applied to:
- Every terminal node. (NodeToProcess & NodeKeyword are both null/empty)
- A directly assigned terminal node. (NodeToProcess is assigned and not null)
- The resulting node of a given keyword. (NodeKeyword returns a non-null terminalNode)

I've also added xml comments for everything public that was added this time (my bad for not doing this in earlier PRs lol)
