### PR TITLE
Add [HelpURL] attribute to most Scriptable Objects

### DIFF
--- a/DawnLib.Dusk/src/API/AssetLoading/ContentContainer.cs
+++ b/DawnLib.Dusk/src/API/AssetLoading/ContentContainer.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 namespace Dusk;
 
 [CreateAssetMenu(fileName = "New Content Container", menuName = $"{DuskModConstants.MenuName}/Content Container", order = DuskModConstants.DuskModInfoOrder)]
+[HelpURL("https://thunderstore.io/c/lethal-company/p/TeamXiaolan/DawnLib/wiki/4099-b2-registering-via-unity-editor/")]
 public class ContentContainer : ScriptableObject
 {
     public List<AssetBundleData> assetBundles;

--- a/DawnLib.Dusk/src/API/Auto/DuskModInformation.cs
+++ b/DawnLib.Dusk/src/API/Auto/DuskModInformation.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 namespace Dusk;
 
 [CreateAssetMenu(fileName = "Mod Information", menuName = $"{DuskModConstants.MenuName}/Mod Information", order = DuskModConstants.DuskModInfoOrder)]
+[HelpURL("https://thunderstore.io/c/lethal-company/p/TeamXiaolan/DawnLib/wiki/4099-b2-registering-via-unity-editor/")]
 public class DuskModInformation : ScriptableObject
 {
     [field: SerializeField]

--- a/DawnLib.Dusk/src/API/Definitions/Achievements/DuskDiscoveryAchievementDefinition.cs
+++ b/DawnLib.Dusk/src/API/Definitions/Achievements/DuskDiscoveryAchievementDefinition.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 namespace Dusk;
 
 [CreateAssetMenu(fileName = "New Discovery Achievement Definition", menuName = $"{DuskModConstants.Achievements}/Discovery Definition")]
+[HelpURL("https://thunderstore.io/c/lethal-company/p/TeamXiaolan/DawnLib/wiki/4107-d1-achievements/")]
 public class DuskDiscoveryAchievement : DuskAchievementDefinition, IProgress
 {
     [Tooltip("Unique string ID for each discovery to account for progress.")]

--- a/DawnLib.Dusk/src/API/Definitions/Achievements/DuskInstantAchievementDefinition.cs
+++ b/DawnLib.Dusk/src/API/Definitions/Achievements/DuskInstantAchievementDefinition.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 namespace Dusk;
 
 [CreateAssetMenu(fileName = "New Instant Achievement Definition", menuName = $"{DuskModConstants.Achievements}/Instant Definition")]
+[HelpURL("https://thunderstore.io/c/lethal-company/p/TeamXiaolan/DawnLib/wiki/4107-d1-achievements/")]
 public class DuskInstantAchievement : DuskAchievementDefinition
 {
     [field: SerializeField]

--- a/DawnLib.Dusk/src/API/Definitions/Achievements/DuskParentAchievementDefinition.cs
+++ b/DawnLib.Dusk/src/API/Definitions/Achievements/DuskParentAchievementDefinition.cs
@@ -6,6 +6,7 @@ using UnityEngine.Serialization;
 namespace Dusk;
 
 [CreateAssetMenu(fileName = "New Parent Achievement Definition", menuName = $"{DuskModConstants.Achievements}/Parent Definition")]
+[HelpURL("https://thunderstore.io/c/lethal-company/p/TeamXiaolan/DawnLib/wiki/4107-d1-achievements/")]
 public class DuskParentAchievement : DuskAchievementDefinition, IProgress
 {
     [field: SerializeReference]

--- a/DawnLib.Dusk/src/API/Definitions/Achievements/DuskStatAchievementDefinition.cs
+++ b/DawnLib.Dusk/src/API/Definitions/Achievements/DuskStatAchievementDefinition.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 namespace Dusk;
 
 [CreateAssetMenu(fileName = "New Stat Achievement Definition", menuName = $"{DuskModConstants.Achievements}/Stat Definition")]
+[HelpURL("https://thunderstore.io/c/lethal-company/p/TeamXiaolan/DawnLib/wiki/4107-d1-achievements/")]
 public class DuskStatAchievement : DuskAchievementDefinition, IProgress
 {
     public class StatSaveData(bool completed, float currentProgress) : AchievementSaveData(completed)

--- a/DawnLib.Dusk/src/API/Definitions/Dungeon/DuskAdditionalTilesDefinition.cs
+++ b/DawnLib.Dusk/src/API/Definitions/Dungeon/DuskAdditionalTilesDefinition.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 namespace Dusk;
 
 [CreateAssetMenu(fileName = "New Additional Tiles Definition", menuName = $"{DuskModConstants.Definitions}/Additional Tiles Definition")]
+[HelpURL("https://thunderstore.io/c/lethal-company/p/TeamXiaolan/DawnLib/wiki/4110-c8-additional-tilesets/")]
 public class DuskAdditionalTilesDefinition : DuskContentDefinition<DawnTileSetInfo>
 {
     [Flags]

--- a/DawnLib.Dusk/src/API/Definitions/Dungeon/DuskDungeonDefinition.cs
+++ b/DawnLib.Dusk/src/API/Definitions/Dungeon/DuskDungeonDefinition.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 namespace Dusk;
 
 [CreateAssetMenu(fileName = "New Dungeon Definition", menuName = $"{DuskModConstants.Definitions}/Dungeon Definition")]
+[HelpURL("https://thunderstore.io/c/lethal-company/p/TeamXiaolan/DawnLib/wiki/4730-interiors-editor-setup/")]
 public class DuskDungeonDefinition : DuskContentDefinition<DawnDungeonInfo>
 {
     [field: SerializeField]

--- a/DawnLib.Dusk/src/API/Definitions/Enemies/DuskEnemyDefinition.cs
+++ b/DawnLib.Dusk/src/API/Definitions/Enemies/DuskEnemyDefinition.cs
@@ -18,6 +18,7 @@ public enum SpawnTable
 }
 
 [CreateAssetMenu(fileName = "New Enemy Definition", menuName = $"{DuskModConstants.Definitions}/Enemy Definition")]
+[HelpURL("https://thunderstore.io/c/lethal-company/p/TeamXiaolan/DawnLib/wiki/4100-c4-enemies/")]
 public class DuskEnemyDefinition : DuskContentDefinition<DawnEnemyInfo>
 {
     [field: FormerlySerializedAs("enemyType")]

--- a/DawnLib.Dusk/src/API/Definitions/Items/DuskItemDefinition.cs
+++ b/DawnLib.Dusk/src/API/Definitions/Items/DuskItemDefinition.cs
@@ -11,6 +11,7 @@ using UnityEngine.Serialization;
 namespace Dusk;
 
 [CreateAssetMenu(fileName = "New Item Definition", menuName = $"{DuskModConstants.Definitions}/Item Definition")]
+[HelpURL("https://thunderstore.io/c/lethal-company/p/TeamXiaolan/DawnLib/wiki/4105-c7-items/")]
 public class DuskItemDefinition : DuskContentDefinition<DawnItemInfo>
 {
     [field: FormerlySerializedAs("item")]

--- a/DawnLib.Dusk/src/API/Definitions/MapObjects/DuskMapObjectDefinition.cs
+++ b/DawnLib.Dusk/src/API/Definitions/MapObjects/DuskMapObjectDefinition.cs
@@ -9,6 +9,7 @@ using UnityEngine.Serialization;
 namespace Dusk;
 
 [CreateAssetMenu(fileName = "New Map Definition", menuName = $"{DuskModConstants.Definitions}/Map Object Definition")]
+[HelpURL("https://thunderstore.io/c/lethal-company/p/TeamXiaolan/DawnLib/wiki/4103-c5-insideoutside-hazards/")]
 public class DuskMapObjectDefinition : DuskContentDefinition<DawnMapObjectInfo>
 {
     [field: FormerlySerializedAs("gameObject")]

--- a/DawnLib.Dusk/src/API/Definitions/Moons/DuskMoonDefinition.cs
+++ b/DawnLib.Dusk/src/API/Definitions/Moons/DuskMoonDefinition.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 namespace Dusk;
 
 [CreateAssetMenu(fileName = "New Moon Definition", menuName = $"{DuskModConstants.Definitions}/Moon Definition")]
+[HelpURL("https://thunderstore.io/c/lethal-company/p/TeamXiaolan/DawnLib/wiki/4676-moons-editor-setup/")]
 public class DuskMoonDefinition : DuskContentDefinition<DawnMoonInfo>
 {
     [field: SerializeField]

--- a/DawnLib.Dusk/src/API/Definitions/StoryLogs/DuskStoryLogDefinition.cs
+++ b/DawnLib.Dusk/src/API/Definitions/StoryLogs/DuskStoryLogDefinition.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 namespace Dusk;
 
 [CreateAssetMenu(fileName = "New StoryLog Definition", menuName = $"{DuskModConstants.Definitions}/StoryLog Definition")]
+[HelpURL("https://thunderstore.io/c/lethal-company/p/TeamXiaolan/DawnLib/wiki/")]
 public class DuskStoryLogDefinition : DuskContentDefinition<DawnStoryLogInfo>
 {
     [field: SerializeField]

--- a/DawnLib.Dusk/src/API/Definitions/Surfaces/DuskSurfaceDefinition.cs
+++ b/DawnLib.Dusk/src/API/Definitions/Surfaces/DuskSurfaceDefinition.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 namespace Dusk;
 
 [CreateAssetMenu(fileName = "New Surface Definition", menuName = $"{DuskModConstants.Definitions}/Surface Definition")]
+[HelpURL("https://thunderstore.io/c/lethal-company/p/TeamXiaolan/DawnLib/wiki/")]
 public class DuskSurfaceDefinition : DuskContentDefinition<DawnSurfaceInfo>
 {
     [field: SerializeField]

--- a/DawnLib.Dusk/src/API/Definitions/Terminal/DuskTerminalCommandDefinition.cs
+++ b/DawnLib.Dusk/src/API/Definitions/Terminal/DuskTerminalCommandDefinition.cs
@@ -91,6 +91,7 @@ public class SimpleInputCommand
 }
 
 [CreateAssetMenu(fileName = "New TerminalCommand Definition", menuName = $"{DuskModConstants.Definitions}/TerminalCommand Definition")]
+[HelpURL("https://thunderstore.io/c/lethal-company/p/TeamXiaolan/DawnLib/wiki/4650-c9-terminal-commands/")]
 public class DuskTerminalCommandDefinition : DuskContentDefinition<DawnTerminalCommandInfo>
 {
     [field: SerializeField]

--- a/DawnLib.Dusk/src/API/Definitions/Unlockables/DuskUnlockableDefinition.cs
+++ b/DawnLib.Dusk/src/API/Definitions/Unlockables/DuskUnlockableDefinition.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 namespace Dusk;
 
 [CreateAssetMenu(fileName = "New Unlockable Definition", menuName = $"{DuskModConstants.Definitions}/Unlockable Definition")]
+[HelpURL("https://thunderstore.io/c/lethal-company/p/TeamXiaolan/DawnLib/wiki/4104-c6-ship-upgradesdecors/")]
 public class DuskUnlockableDefinition : DuskContentDefinition<DawnUnlockableItemInfo>
 {
     [field: SerializeField]

--- a/DawnLib.Dusk/src/API/Definitions/Vehicles/DuskVehicleDefinition.cs
+++ b/DawnLib.Dusk/src/API/Definitions/Vehicles/DuskVehicleDefinition.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 namespace Dusk;
 
 [CreateAssetMenu(fileName = "New Vehicle Definition", menuName = $"{DuskModConstants.Definitions}/Vehicle Definition")]
+[HelpURL("https://thunderstore.io/c/lethal-company/p/TeamXiaolan/DawnLib/wiki/4108-d2-vehicles/")]
 public class DuskVehicleDefinition : DuskContentDefinition<DawnVehicleInfo>, INamespaced<DuskVehicleDefinition>
 {
     [field: SerializeField]

--- a/DawnLib.Dusk/src/API/Definitions/Weathers/DuskWeatherDefinition.cs
+++ b/DawnLib.Dusk/src/API/Definitions/Weathers/DuskWeatherDefinition.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 namespace Dusk;
 
 [CreateAssetMenu(fileName = "New Weather Definition", menuName = $"{DuskModConstants.Definitions}/Weather Definition")]
+[HelpURL("https://thunderstore.io/c/lethal-company/p/TeamXiaolan/DawnLib/wiki/4106-c3-weathers/")]
 public class DuskWeatherDefinition : DuskContentDefinition<DawnWeatherEffectInfo>
 {
     [field: SerializeField]

--- a/DawnLib.Dusk/src/API/DuskPredicates/DuskPredicate.cs
+++ b/DawnLib.Dusk/src/API/DuskPredicates/DuskPredicate.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 
 namespace Dusk;
 
+[HelpURL("https://thunderstore.io/c/lethal-company/p/TeamXiaolan/DawnLib/wiki/4101-c-moons/")]
 public abstract class DuskPredicate : ScriptableObject, IPredicate
 {
     public abstract void Register(NamespacedKey namespacedKey);

--- a/DawnLib.Dusk/src/API/PricingStrategies/DuskPricingStrategy.cs
+++ b/DawnLib.Dusk/src/API/PricingStrategies/DuskPricingStrategy.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 
 namespace Dusk;
 
+[HelpURL("https://thunderstore.io/c/lethal-company/p/TeamXiaolan/DawnLib/wiki/")]
 public abstract class DuskPricingStrategy : ScriptableObject, IProvider<int>
 {
     public abstract void Register(NamespacedKey id);

--- a/DawnLib.Dusk/src/API/TerminalPredicates/AchievementPredicate.cs
+++ b/DawnLib.Dusk/src/API/TerminalPredicates/AchievementPredicate.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 namespace Dusk;
 
 [CreateAssetMenu(menuName = $"{DuskModConstants.TerminalPredicates}/Achievement Unlock Requirement", fileName = "New Achievement Predicate", order = DuskModConstants.PredicateOrder)]
+[HelpURL("https://thunderstore.io/c/lethal-company/p/TeamXiaolan/DawnLib/wiki/4107-d1-achievements/")]
 public class AchievementPredicate : DuskTerminalPredicate
 {
     [SerializeField]

--- a/DawnLib.Dusk/src/API/TerminalPredicates/DuskTerminalPredicate.cs
+++ b/DawnLib.Dusk/src/API/TerminalPredicates/DuskTerminalPredicate.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 
 namespace Dusk;
 
+[HelpURL("https://thunderstore.io/c/lethal-company/p/TeamXiaolan/DawnLib/wiki/")]
 public abstract class DuskTerminalPredicate : ScriptableObject, ITerminalPurchasePredicate
 {
     public abstract void Register(NamespacedKey namespacedKey);


### PR DESCRIPTION
The ones left without a URL are subclasses of those with it.

Not all of Scriptable Objects have a corresponding dedicated page, in those cases URL defaults to the root of the wiki.