### PR TITLE
Port away from deprecated BepInEx method ConfigFile.GetConfigEntries

### DIFF
--- a/DawnLib.Dusk/src/API/Config/ConfigManager.cs
+++ b/DawnLib.Dusk/src/API/Config/ConfigManager.cs
@@ -77,6 +77,8 @@ public class ConfigManager(ConfigFile file)
     public static ConfigEntryBase? FindEntry(ConfigFile file, string section, string key)
     {
         ConfigDefinition definition = new(section, key);
-        return file.GetConfigEntries().FirstOrDefault(x => x.Definition == definition);
+        // Note: explicit cast needed due to https://github.com/BepInEx/BepInEx/issues/1305
+        var entries = ((IDictionary<ConfigDefinition, ConfigEntryBase>)file).Values;
+        return entries.FirstOrDefault(x => x.Definition == definition);
     }
 }

--- a/DawnLib.Dusk/src/API/Config/ConfigReader.cs
+++ b/DawnLib.Dusk/src/API/Config/ConfigReader.cs
@@ -201,7 +201,9 @@ public class ConfigReader : MonoBehaviour
         Debuggers.Configs?.Log($"ConfigReader: pluginGuid={pluginGuid}, section={section}, key={key}");
         ConfigFile config = pluginInfo.Instance.Config;
         ConfigDefinition definition = new(section, key);
-        foreach (ConfigEntryBase configEntryBase in config.GetConfigEntries())
+        // Note: explicit cast needed due to https://github.com/BepInEx/BepInEx/issues/1305
+        var entries = ((IDictionary<ConfigDefinition, ConfigEntryBase>)config).Values;
+        foreach (ConfigEntryBase configEntryBase in entries)
         {
             ConfigDefinition existingDefinition = configEntryBase.Definition;
             Debuggers.Configs?.Log($"Existing definition: Section: {existingDefinition.Section} | Key: {existingDefinition.Key}");


### PR DESCRIPTION
Amends 5f21db30e5013689e42d33c2e94c92af4b928a57

Fixed in upstream BepInEx but never backported to 5-lts branch: https://github.com/BepInEx/BepInEx/commit/e473f08e0a85fffd818f310c783458037a079ded

Upsteam BepInEx issue to change the [Obsolete] attribute help text: https://github.com/BepInEx/BepInEx/issues/1305