### PR TITLE
fixed issue when close the terminal

### DIFF
--- a/DawnLib/src/Internal/ModCompats/LethalQuantitiesCompat.cs
+++ b/DawnLib/src/Internal/ModCompats/LethalQuantitiesCompat.cs
@@ -25,7 +25,15 @@ static class LethalQuantitiesCompat
         _lqConverter = new AnimationCurveTypeConverter();
         _dawnConverter = ExtendedTOML.WrapConverter(new AnimationCurveConverter());
 
-        DawnPlugin.Hooks.Add(new Hook(AccessTools.DeclaredMethod(typeof(LethalQuantities.Patches.RoundManagerPatch), "onStartPrefix"), MarkShouldUseLQConverter));
+        var onStartPrefix = AccessTools.DeclaredMethod(typeof(LethalQuantities.Patches.RoundManagerPatch), "onStartPrefix");
+        if (onStartPrefix != null)
+        {
+            DawnPlugin.Hooks.Add(new Hook(onStartPrefix, MarkShouldUseLQConverter));
+        }
+        else
+        {
+            DawnPlugin.Logger.LogWarning("[LethalQuantitiesCompat] Could not find RoundManagerPatch.onStartPrefix — LQ compat disabled.");
+        }
         On.BepInEx.Configuration.TomlTypeConverter.GetConverter += ReplaceAnimationCurveConverter;
     }
     private static TypeConverter ReplaceAnimationCurveConverter(TomlTypeConverter.orig_GetConverter orig, Type valuetype)

--- a/DawnLib/src/Internal/ModCompats/TerminalFormatterCompat.cs
+++ b/DawnLib/src/Internal/ModCompats/TerminalFormatterCompat.cs
@@ -14,6 +14,14 @@ static class TerminalFormatterCompat
     {
         // teehee maxxing :3
         alreadyPatched = true;
-        DawnPlugin.ILHooks.Add(new ILHook(AccessTools.DeclaredMethod(typeof(TerminalFormatter.Nodes.Store), "GetNodeText"), TerminalPatches.UseFailedNameResults));
+        var getNodeText = AccessTools.DeclaredMethod(typeof(TerminalFormatter.Nodes.Store), "GetNodeText");
+        if (getNodeText != null)
+        {
+            DawnPlugin.ILHooks.Add(new ILHook(getNodeText, TerminalPatches.UseFailedNameResults));
+        }
+        else
+        {
+            DawnPlugin.Logger.LogWarning("[TerminalFormatterCompat] Could not find Store.GetNodeText — TerminalFormatter compat disabled.");
+        }
     }
 }

--- a/Thunderstore/CHANGELOG.md
+++ b/Thunderstore/CHANGELOG.md
@@ -1,4 +1,8 @@
-# v0.9.23
+# v0.9.24
+
+- Added null-safety checks to `LethalQuantitiesCompat` and `TerminalFormatterCompat` to prevent a crash when a dependency updates and renames an internal method.
+
+## v0.9.23
 
 - Solved fake extra fire exit existing.
 - Cleaned up code for more compatibility with other mods.


### PR DESCRIPTION
 ## Problem

  AccessTools.DeclaredMethod() returns null when the target method doesn't
  exist — for example, when a dependency (LethalQuantities or TerminalFormatter)
  updates and renames an internal method.

  Previously, the returned null was passed directly into new Hook(null, ...)
  and new ILHook(null, ...), which throws a NullReferenceException. Since both
  of these calls happen inside DawnPlugin.Awake(), the exception crashes the
  entire plugin initialization — meaning no patches get applied at all,
  including terminal-related ones, which causes in-game issues like the
  terminal not responding to Tab/Esc.

  ## Fix

  Added a null check on the result of AccessTools.DeclaredMethod() in both
  LethalQuantitiesCompat and TerminalFormatterCompat. If the method is not
  found, a warning is logged and the compat layer is skipped gracefully
  instead of crashing the whole plugin.

  ## Files changed

  - DawnLib/src/Internal/ModCompats/LethalQuantitiesCompat.cs
  - DawnLib/src/Internal/ModCompats/TerminalFormatterCompat.cs